### PR TITLE
Add lifecycle events for hiding / showing views before / after nav transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 React view manager similar to [UINavigationController][ios-controller]
 
-## Instalation
+## Installation
 
 ```bash
 npm install react-navigation-controller
@@ -179,6 +179,46 @@ Addtional options - see [pushView()](#push-options)
 If set to `true`, the navigationController will save the state
 of each view that gets pushed onto the stack. When `popView()` is called,
 the navigationController will rehydrate the state of the view before it is shown.
+
+## Lifecycle Events
+
+Similar to the React component lifecycle, the navigationController will
+call lifecycle events on the component at certain stages.
+
+Lifecycle events can trigger actions when views transition in or out,
+instead of mounted or unmounted:
+
+```
+class HelloView extends React.Component {
+  navigationControllerDidShowView() {
+    // Do something when the show transition is finished,
+    // like fade in an element.
+  }
+  navigationControllerWillHideView() {
+    // Do something when the hide transition will start,
+    // like fade out an element.
+  }
+  render() {
+    return <div>Hello, {this.props.name}!</div>;
+  }
+}
+```
+
+### `view.navigationControllerWillHideView()`
+
+Invoked immediately before the previous view will be hidden.
+
+### `view.navigationControllerWillShowView()`
+
+Invoked immediately before the next view will be shown.
+
+### `view.navigationControllerDidHideView()`
+
+Invoked immediately after the previous view has been hidden.
+
+### `view.navigationControllerDidShowView()`
+
+Invoked immediately after the next view has been shown.
 
 ## Styling
 

--- a/examples/src/view.jsx
+++ b/examples/src/view.jsx
@@ -31,6 +31,24 @@ class View extends React.Component {
       counter: this.state.counter + 1
     });
   }
+  componentDidMount() {
+    console.log('component did mount', this.props.index);
+  }
+  navigationControllerWillShowView() {
+    console.log('will show view', this.props.index);
+  }
+  navigationControllerDidShowView() {
+    console.log('did show view', this.props.index);
+  }
+  navigationControllerWillHideView() {
+    console.log('will hide view', this.props.index);
+  }
+  navigationControllerDidHideView() {
+    console.log('did hide view', this.props.index);
+  }
+  componentWillUnmount() {
+    console.log('component will unmount', this.props.index);
+  }
   onNext() {
     const view = <View index={this.props.index+1} />;
     this.props.navigationController.pushView(view, {

--- a/examples/src/view.jsx
+++ b/examples/src/view.jsx
@@ -31,24 +31,6 @@ class View extends React.Component {
       counter: this.state.counter + 1
     });
   }
-  componentDidMount() {
-    console.log('component did mount', this.props.index);
-  }
-  navigationControllerWillShowView() {
-    console.log('will show view', this.props.index);
-  }
-  navigationControllerDidShowView() {
-    console.log('did show view', this.props.index);
-  }
-  navigationControllerWillHideView() {
-    console.log('will hide view', this.props.index);
-  }
-  navigationControllerDidHideView() {
-    console.log('did hide view', this.props.index);
-  }
-  componentWillUnmount() {
-    console.log('component will unmount', this.props.index);
-  }
   onNext() {
     const view = <View index={this.props.index+1} />;
     this.props.navigationController.pushView(view, {

--- a/spec/navigation-controller.spec.jsx
+++ b/spec/navigation-controller.spec.jsx
@@ -86,9 +86,6 @@ describe('NavigationController', () => {
       expect(viewWrapper1).to.have.deep.property(`style.${transformPrefix}`);
     });
   });
-  describe('#componentWillUnmout', () => {
-    
-  });
   describe('#__transformViews', () => {
     beforeEach(done => {
       requestAnimationFrame(() => {
@@ -461,6 +458,24 @@ describe('NavigationController', () => {
           done();
         });
       })
+    });
+    it('calls lifecycle events', (done) => {
+      const didShowViewSpy = sinon.spy();
+      const didHideViewSpy = sinon.spy();
+      controller.__pushView(<ViewB />, {
+        transition: Transition.type.NONE
+      });
+      controller.forceUpdate(() => {
+        let prevView = controller.refs['view-0'];
+        let nextView = controller.refs['view-1'];
+        prevView.navigationControllerDidHideView = didHideViewSpy;
+        nextView.navigationControllerDidShowView = didShowViewSpy;
+        requestAnimationFrame(() => {
+          expect(didHideViewSpy.calledOnce).to.be.true;
+          expect(didShowViewSpy.calledOnce).to.be.true;
+          done();
+        });
+      });
     });
   });
   describe('#__popView', () => {

--- a/spec/navigation-controller.spec.jsx
+++ b/spec/navigation-controller.spec.jsx
@@ -677,7 +677,7 @@ describe('NavigationController', () => {
           didShow: sinon.spy()
         }
       }
-      var stub = sinon.stub(controller, '__transitionViews', (options) => {
+      const stub = sinon.stub(controller, '__transitionViews', (options) => {
         let prevView = controller.refs['view-0'];
         if (prevView) {
           prevView.navigationControllerWillHideView = e.prevView.willHide;

--- a/spec/navigation-controller.spec.jsx
+++ b/spec/navigation-controller.spec.jsx
@@ -32,7 +32,7 @@ describe('NavigationController', () => {
     );
     viewWrapper0 = controller['__view-wrapper-0'];
     viewWrapper1 = controller['__view-wrapper-1'];
-  })
+  });
   it('exports a component', () => {
     let controller = renderIntoDocument(
       <NavigationController views={views} />
@@ -459,32 +459,6 @@ describe('NavigationController', () => {
         });
       })
     });
-    it('calls lifecycle events', (done) => {
-      const willHideViewSpy = sinon.spy();
-      const willShowViewSpy = sinon.spy();
-      const didHideViewSpy = sinon.spy();
-      const didShowViewSpy = sinon.spy();
-      var stub = sinon.stub(controller, '__transitionViews', function (options) {
-        let prevView = controller.refs['view-0'];
-        let nextView = controller.refs['view-1'];
-        prevView.navigationControllerWillHideView = willHideViewSpy;
-        nextView.navigationControllerWillShowView = willShowViewSpy;
-        prevView.navigationControllerDidHideView = didHideViewSpy;
-        nextView.navigationControllerDidShowView = didShowViewSpy;
-        stub.restore();
-        controller.__transitionViews(options);
-        requestAnimationFrame(() => {
-          expect(willHideViewSpy.calledOnce).to.be.true;
-          expect(willShowViewSpy.calledOnce).to.be.true;
-          expect(didHideViewSpy.calledOnce).to.be.true;
-          expect(didShowViewSpy.calledOnce).to.be.true;
-          done();
-        });
-      });
-      controller.__pushView(<ViewB />, {
-        transition: Transition.type.NONE
-      });
-    });
   });
   describe('#__popView', () => {
     beforeEach(done => {
@@ -688,6 +662,117 @@ describe('NavigationController', () => {
         expect(ref).not.to.be.null;
         expect(ref.props.navigationController).to.equal(controller);
         done();
+      });
+    });
+  });
+  describe('Lifecycle Events', () => {
+    let stubLifecycleEvents = (onTransitionViews) => {
+      const e = {
+        prevView: {
+          willHide: sinon.spy(),
+          didHide: sinon.spy()
+        },
+        nextView: {
+          willShow: sinon.spy(),
+          didShow: sinon.spy()
+        }
+      }
+      var stub = sinon.stub(controller, '__transitionViews', (options) => {
+        let prevView = controller.refs['view-0'];
+        if (prevView) {
+          prevView.navigationControllerWillHideView = e.prevView.willHide;
+          prevView.navigationControllerDidHideView = e.prevView.didHide;
+        }
+        let nextView = controller.refs['view-1'];
+        if (nextView) {
+          nextView.navigationControllerWillShowView = e.nextView.willShow;
+          nextView.navigationControllerDidShowView = e.nextView.didShow;
+        }
+        stub.restore();
+        controller.__transitionViews(options);
+        onTransitionViews();
+      });
+      return e;
+    };
+    describe('#__pushView', () => {
+      beforeEach(done => {
+        requestAnimationFrame(() => {
+          done();
+        });
+      });
+      it('calls events with a "none" transition', (done) => {
+        const e = stubLifecycleEvents(() => {
+          expect(e.prevView.willHide.calledOnce).to.be.true;
+          expect(e.nextView.willShow.calledOnce).to.be.true;
+          expect(e.prevView.didHide.calledOnce).to.be.false;
+          expect(e.nextView.didShow.calledOnce).to.be.false;
+        });
+        controller.__pushView(<ViewB />, {
+          transition: Transition.type.NONE,
+          onComplete() {
+            expect(e.prevView.didHide.calledOnce).to.be.true;
+            expect(e.nextView.didShow.calledOnce).to.be.true;
+            done();
+          }
+        });
+      });
+      it('calls events with a built-in spring animation', (done) => {
+        const e = stubLifecycleEvents(() => {
+          expect(e.prevView.willHide.calledOnce).to.be.true;
+          expect(e.nextView.willShow.calledOnce).to.be.true;
+          expect(e.prevView.didHide.calledOnce).to.be.false;
+          expect(e.nextView.didShow.calledOnce).to.be.false;
+        });
+        controller.__pushView(<ViewB />, {
+          transition: Transition.type.PUSH_LEFT,
+          onComplete() {
+            expect(e.prevView.didHide.calledOnce).to.be.true;
+            expect(e.nextView.didShow.calledOnce).to.be.true;
+            done();
+          }
+        });
+      });
+    });
+    describe('#__popView', () => {
+      beforeEach(done => {
+        controller = renderIntoDocument(
+          <NavigationController views={[<ViewA />,<ViewB />]} />
+        );
+        requestAnimationFrame(() => {
+          done();
+        });
+      });
+      it('calls events with a "none" transition', (done) => {
+        const e = stubLifecycleEvents(() => {
+          expect(e.prevView.willHide.calledOnce).to.be.true;
+          expect(e.nextView.willShow.calledOnce).to.be.true;
+          expect(e.prevView.didHide.calledOnce).to.be.false;
+          expect(e.nextView.didShow.calledOnce).to.be.false;
+        });
+        controller.__popView({
+          transition: Transition.type.NONE,
+          onComplete() {
+            expect(e.prevView.didHide.calledOnce).to.be.true;
+            expect(e.nextView.didShow.calledOnce).to.be.true;
+            done();
+          }
+        });
+      });
+      it('calls events with a built-in spring animation', (done) => {
+        const e = stubLifecycleEvents(() => {
+          expect(e.prevView.willHide.calledOnce).to.be.true;
+          expect(e.nextView.willShow.calledOnce).to.be.true;
+          expect(e.prevView.didHide.calledOnce).to.be.false;
+          expect(e.nextView.didShow.calledOnce).to.be.false;
+        });
+        controller.__popView({
+          transition: Transition.type.PUSH_LEFT,
+          onComplete() {
+            expect(e.prevView.didHide.calledOnce).to.be.true;
+            expect(e.nextView.didShow.calledOnce).to.be.true;
+            done();
+          }
+        });
       });
     });
   });

--- a/spec/navigation-controller.spec.jsx
+++ b/spec/navigation-controller.spec.jsx
@@ -460,21 +460,29 @@ describe('NavigationController', () => {
       })
     });
     it('calls lifecycle events', (done) => {
-      const didShowViewSpy = sinon.spy();
+      const willHideViewSpy = sinon.spy();
+      const willShowViewSpy = sinon.spy();
       const didHideViewSpy = sinon.spy();
-      controller.__pushView(<ViewB />, {
-        transition: Transition.type.NONE
-      });
-      controller.forceUpdate(() => {
+      const didShowViewSpy = sinon.spy();
+      var stub = sinon.stub(controller, '__transitionViews', function (options) {
         let prevView = controller.refs['view-0'];
         let nextView = controller.refs['view-1'];
+        prevView.navigationControllerWillHideView = willHideViewSpy;
+        nextView.navigationControllerWillShowView = willShowViewSpy;
         prevView.navigationControllerDidHideView = didHideViewSpy;
         nextView.navigationControllerDidShowView = didShowViewSpy;
+        stub.restore();
+        controller.__transitionViews(options);
         requestAnimationFrame(() => {
+          expect(willHideViewSpy.calledOnce).to.be.true;
+          expect(willShowViewSpy.calledOnce).to.be.true;
           expect(didHideViewSpy.calledOnce).to.be.true;
           expect(didShowViewSpy.calledOnce).to.be.true;
           done();
         });
+      });
+      controller.__pushView(<ViewB />, {
+        transition: Transition.type.NONE
       });
     });
   });

--- a/src/navigation-controller.jsx
+++ b/src/navigation-controller.jsx
@@ -206,10 +206,21 @@ class NavigationController extends React.Component {
     // Hide the previous view wrapper
     const prevViewWrapper = this[`__view-wrapper-${prev}`];
           prevViewWrapper.style.display = 'none';
+    // Did hide view lifecycle event
+    const prevView = this.refs['view-0'];
+    if (prevView && typeof prevView.navigationControllerDidHideView === 'function') {
+      prevView.navigationControllerDidHideView(this);
+    }
+    // Did show view lifecycle event
+    const nextView = this.refs['view-1'];
+    if (nextView && typeof nextView.navigationControllerDidShowView === 'function') {
+      nextView.navigationControllerDidShowView(this);
+    }
     // Unmount the previous view
     const mountedViews = [];
           mountedViews[prev] = null;
           mountedViews[next] = last(this.state.views);
+
     this.setState({
       transition: null,
       mountedViews: mountedViews
@@ -254,6 +265,16 @@ class NavigationController extends React.Component {
         onComplete();
       }
     };
+    // Will hide view lifecycle event
+    const prevView = this.refs['view-0'];
+    if (prevView && typeof prevView.navigationControllerWillHideView === 'function') {
+      prevView.navigationControllerWillHideView(this);
+    }
+    // Will show view lifecycle event
+    const nextView = this.refs['view-1'];
+    if (nextView && typeof nextView.navigationControllerWillShowView === 'function') {
+      nextView.navigationControllerWillShowView(this);
+    }
     // Built-in transition
     if (typeof transition === 'number') {
       // Manually transition the views
@@ -281,7 +302,7 @@ class NavigationController extends React.Component {
     if (typeof transition === 'function') {
       const [prev,next] = this.__viewIndexes;
       const prevView = this[`__view-wrapper-${prev}`];
-      const nextView = this[`__view-wrapper-${next}`]; 
+      const nextView = this[`__view-wrapper-${next}`];
       transition(prevView, nextView, () => {
         this.__animateViewsComplete();
         this.__transitionViewsComplete();


### PR DESCRIPTION
Found myself wanting predictable lifecycle events in my views, rather than sprinkling code into onComplete callbacks e.g. kicking off animations. The `componentDidMount` event is often not appropriate to initiate certain things on the view since it's still animating the transition at that point.

Added the following lifecycle events:

`navigationControllerWillHideView`
`navigationControllerWillShowView`
`navigationControllerDidHideView`
`navigationControllerDidShowView`
