### PR TITLE
Upgrade to React 0.14 (split out ReactDOM)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "minimist": "^1.2.0",
     "mocha": "^2.3.3",
     "phantomjs": "^1.9.18",
-    "react": "0.13.3",
+    "react": "0.14.5",
+    "react-dom": "0.14.5",
     "sinon": "^1.17.1",
     "webpack": "^1.12.2",
     "webpack-dev-server": "^1.12.0"

--- a/src/navigation-controller.jsx
+++ b/src/navigation-controller.jsx
@@ -1,4 +1,5 @@
 const React = require('react');
+const ReactDOM = require('react-dom');
 
 const rebound = require('rebound');
 const {
@@ -114,8 +115,8 @@ class NavigationController extends React.Component {
 
   componentDidMount() {
     // Cache the view wrappers
-    this['__view-wrapper-0'] = React.findDOMNode(this.refs[`view-wrapper-0`]);
-    this['__view-wrapper-1'] = React.findDOMNode(this.refs[`view-wrapper-1`]);
+    this['__view-wrapper-0'] = ReactDOM.findDOMNode(this.refs[`view-wrapper-0`]);
+    this['__view-wrapper-1'] = ReactDOM.findDOMNode(this.refs[`view-wrapper-1`]);
     // Position the wrappers
     this.__transformViews(0, 0, -100, 0);
     // Push the last view
@@ -130,7 +131,7 @@ class NavigationController extends React.Component {
 
   /**
    * Translate the view wrappers by a specified percentage
-   * 
+   *
    * @param {number} prevX
    * @param {number} prevY
    * @param {number} nextX
@@ -416,7 +417,7 @@ class NavigationController extends React.Component {
         const state = this.__viewStates.pop();
         // Rehydrate the state
         if (state) {
-          nextView.setState(state);  
+          nextView.setState(state);
         }
       }
       // Transition
@@ -489,7 +490,7 @@ class NavigationController extends React.Component {
         const state = this.__viewStates[0];
         // Rehydrate the state
         if (state) {
-          rootView.setState(state);  
+          rootView.setState(state);
         }
       }
       // Clear view states


### PR DESCRIPTION
Pretty small diff, but requires React 0.14—not sure how you want to go about supporting both pre 0.14 and 0.14+.

In React 0.14, `this.refs` points directly to the DOM nodes, so `ReactDOM.findDOMNode` probably isn't even necessary.