### PR TITLE
Add new property preserveDom that kept the dom tree.

### DIFF
--- a/examples/src/example.jsx
+++ b/examples/src/example.jsx
@@ -22,6 +22,16 @@ class App extends React.Component {
           preserveState
           transitionTension={10}
           transitionFriction={6} />
+        <h2>Preserve DOM</h2>
+        <p>
+          Preserve DOM for views on the stack, so that all status including
+          srolling position can be reserved.
+        </p>
+        <NavigationController
+          views={[<View />]}
+          preserveDom
+          transitionTension={10}
+          transitionFriction={6} />
       </main>
     )
   }

--- a/examples/src/view.jsx
+++ b/examples/src/view.jsx
@@ -69,6 +69,20 @@ class View extends React.Component {
             Show Modal
           </button>
           {this.renderPopToRootButton()}
+          <div style={{height: '100px', overflow: 'scroll'}}>
+            <div style={{height: '50px'}}>
+            Scroll It: 1
+            </div>
+            <div style={{height: '50px'}}>
+            Scroll It: 2
+            </div>
+            <div style={{height: '50px'}}>
+            Scroll It: 3
+            </div>
+            <div style={{height: '50px'}}>
+            Scroll It: 4
+            </div>
+          </div>
         </section>
       </div>
     )


### PR DESCRIPTION
Sometimes we want to keep the old page not changed when we popView back.
PreserveState only keep the state of the root component, states of children are lost along with
some DOM state like scroll position. I added a new preserveDom mode that just hide the non-visible views than unmounted them.