### PR TITLE
Fix PropTypes.oneOfType usage

### DIFF
--- a/src/navigation-controller.jsx
+++ b/src/navigation-controller.jsx
@@ -561,7 +561,7 @@ NavigationController.propTypes = {
   preserveState: PropTypes.bool,
   transitionTension: PropTypes.number,
   transitionFriction: PropTypes.number,
-  className: PropTypes.oneOf([
+  className: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.object
   ])


### PR DESCRIPTION
We get the following error when using the className prop:

```
Warning: Failed prop type: Invalid prop `className` of value `EquipmentPicker_root_k5EPP` supplied to `NavigationController`, expected one of [null,null].
```

Which is a bit confusing because a string is a valid value for className. After digging into it, I found the fix was a simple as replacing `propTypes.oneOf` with `propTypes.oneOfType`. [See PropTypes docs](https://www.npmjs.com/package/prop-types#usage).